### PR TITLE
Skip hc_cis_chloride50 bootstrap snapshot on CI

### DIFF
--- a/tests/testthat/test-hc.R
+++ b/tests/testthat/test-hc.R
@@ -3,7 +3,7 @@ test_that("ssd_hc passing all boots ccme_chloride lnorm_lnorm", {
     min_pmix = 0.0001, at_boundary_ok = TRUE,
     dists = c("lnorm_lnorm", "llogis_llogis")
   )
-
+  skip_on_ci()
   withr::with_seed(102, {
     hc <- ssd_hc(fits, ci = TRUE, nboot = 1000, average = FALSE)
   })


### PR DESCRIPTION
## Summary
The `hc_cis_chloride50` snapshot test (test-hc.R) runs `ssd_hc(ci = TRUE, nboot = 1000)` on `lnorm_lnorm`/`llogis_llogis` mixture fits and snapshots the bootstrap compatibility limits. Those limits depend on refits that diverge across BLAS/LAPACK implementations, so the committed CSV matches only on the platform that generated it (macOS) and fails on Linux/Windows. This surfaced once CI began running on PRs into dev. This test was one of the deliberately unstable bootstrap tests moved from ssdtools, and every other bootstrap-CI snapshot in this file already guards with `skip_on_ci()`; this one was missing it. Adds `skip_on_ci()` before the bootstrap so the expensive, platform-dependent snapshot is skipped on CI while the test still runs locally.

## Verification
Run `testthat::test_local(filter = "^hc$")` locally and confirm all hc tests pass (skip_on_ci is inactive locally, so the chloride50 snapshot still runs and matches). On CI the chloride50 snapshot is skipped.