### PR TITLE
Drop redundant multi test; make test-llogis actually test llogis

### DIFF
--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -82,26 +82,24 @@ ep <- function(text) {
   invisible(eval(parse(text = text)))
 }
 
-test_dist2 <- function(dist, upadj = 0, multi = FALSE) {
-  if (!multi) {
-    withr::with_seed(97, {
-      data <- data.frame(Conc = ep(glue::glue("ssd_r{dist}(500)")))
-    })
-    fits <- ssd_fit_dists(data = data, dists = dist)
-    tidy <- tidy(fits)
-    testthat::expect_s3_class(tidy, "tbl_df")
-    testthat::expect_identical(names(tidy), c("dist", "term", "est", "se"))
-    testthat::expect_identical(tidy$dist[1], dist)
-    tidy$lower <- tidy$est - tidy$se * 3
-    tidy$upper <- tidy$est + tidy$se * 3
+test_dist2 <- function(dist, upadj = 0) {
+  withr::with_seed(97, {
+    data <- data.frame(Conc = ep(glue::glue("ssd_r{dist}(500)")))
+  })
+  fits <- ssd_fit_dists(data = data, dists = dist)
+  tidy <- tidy(fits)
+  testthat::expect_s3_class(tidy, "tbl_df")
+  testthat::expect_identical(names(tidy), c("dist", "term", "est", "se"))
+  testthat::expect_identical(tidy$dist[1], dist)
+  tidy$lower <- tidy$est - tidy$se * 3
+  tidy$upper <- tidy$est + tidy$se * 3
 
-    default <- ep(glue::glue("formals(ssd_r{dist})"))
-    default$n <- NULL
-    default$chk <- NULL
-    default <- data.frame(term = names(default), default = unlist(default))
+  default <- ep(glue::glue("formals(ssd_r{dist})"))
+  default$n <- NULL
+  default$chk <- NULL
+  default <- data.frame(term = names(default), default = unlist(default))
 
-    tidy <- merge(tidy, default, by = "term", all = "TRUE")
-    testthat::expect_true(all(tidy$default > tidy$lower - upadj))
-    testthat::expect_true(all(tidy$default < tidy$upper + upadj))
-  }
+  tidy <- merge(tidy, default, by = "term", all = "TRUE")
+  testthat::expect_true(all(tidy$default > tidy$lower - upadj))
+  testthat::expect_true(all(tidy$default < tidy$upper + upadj))
 }

--- a/tests/testthat/test-llogis.R
+++ b/tests/testthat/test-llogis.R
@@ -1,3 +1,3 @@
-test_that("invpareto", {
-  test_dist2("invpareto", upadj = 1e-03)
+test_that("llogis", {
+  test_dist2("llogis")
 })

--- a/tests/testthat/test-multi.R
+++ b/tests/testthat/test-multi.R
@@ -1,3 +1,0 @@
-test_that("multi", {
-  test_dist2("multi", multi = TRUE)
-})


### PR DESCRIPTION
## Summary
- Removes `test-multi.R`, which called `test_dist2("multi", multi = TRUE)`. The `multi = TRUE` branch of `test_dist2` contains no assertions, so the test did nothing (it reported as an empty/skipped test every run). It was the only caller of `multi = TRUE`, so the now-unused `multi` argument is removed from the `test_dist2` helper.
- Repurposes `test-llogis.R`, which was a verbatim duplicate of the `invpareto` recovery test in `test-invpareto.R` (mislabeled). It now runs `test_dist2("llogis")`, closing a real gap: llogis parameter recovery previously had no test. Verified it passes with the default tolerance.

## Verification
`testthat::test_local()` passes with no `.new` snapshots; the "multi" empty-test skip is gone and llogis now runs its recovery assertions.