### PR TITLE
Bump version to 0.2.0 and update NEWS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ssdtests
 Title: Tests for ssdtools
-Version: 0.1.0
+Version: 0.2.0
 Authors@R: c(
     person("Joe", "Thorley", , "joe@poissonconsulting.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-7683-4592")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
+# ssdtests 0.2.0
+
+- Added regression tables that fit every curated ssddata dataset: model-averaged BCANZ hazard concentrations (`test-bcanz-hc`) and per-distribution HC5 as a percentage of the geometric mean of the data (`test-hc5-gm`).
+- Added `scripts/ssdtools-coverage.R` to report the ssdtools line coverage produced by the ssdtests suite.
+- Added an introductory vignette (`vignette("ssdtests")`) and expanded the README.
+- Reorganized the tests by subject and documented the snapshot-stability conventions and the ssdtests-versus-ssdtools placement rule in `CONTRIBUTING.md`.
+- Standardized continuous integration on the poissonconsulting reusable workflows.
+- Test hygiene: revived or removed permanently-skipped tests, removed redundant tests, and pruned unused dependencies.
+
 # ssdtests 0.1.0
 
 - Initial release version.


### PR DESCRIPTION
## Summary
Minor release: bumps the package version from 0.1.0 to 0.2.0 and adds a NEWS.md section for 0.2.0 summarising the changes since the initial release (curated-dataset regression tables, the ssdtools-coverage script, the vignette and README, the test reorganisation and hygiene, and the CI standardisation).

## Notes
- NEWS.md is nominally fledge-maintained, but this repo has no git tags and no fledge CI wiring, so fledge has no baseline to work from. The entry was written by hand in the fledge-compatible format so a future fledge run stays consistent.
- This does not create a git tag or a GitHub release; those are held pending your direction (and, for this bcgov fork, are ordinarily an upstream action).