### PR TITLE
Point documentation and badges at bcgov after upstream move

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,9 @@ with `testthat::snapshot_accept()` once verified.
 `scripts/ssdtools-coverage.R` reports the ssdtools line coverage produced by the
 ssdtests suite. It clones the ssdtools branch that corresponds to the current
 ssdtests repo and branch (same org as the `origin` remote, same branch name, so
-`poissonconsulting/ssdtests@dev` is measured against `poissonconsulting/ssdtools@dev`),
+`bcgov/ssdtests@main` is measured against `bcgov/ssdtools@main` and the
+development fork `poissonconsulting/ssdtests@dev` against
+`poissonconsulting/ssdtools@dev`),
 instruments it with covr, runs the ssdtests tests against it, and prints the
 overall and per-file coverage.
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,9 +21,8 @@ Authors@R: c(
   )
 Description: Slow and unstable tests for ssdtools package.
 License: Apache License (== 2.0) | file LICENSE
-URL: https://github.com/poissonconsulting/ssdtests,
-    https://poissonconsulting.github.io/ssdtests/
-BugReports: https://github.com/poissonconsulting/ssdtests/issues
+URL: https://github.com/bcgov/ssdtests, https://bcgov.github.io/ssdtests/
+BugReports: https://github.com/bcgov/ssdtests/issues
 Depends: 
     R (>= 4.1),
     ssdtools (>= 2.6.0)
@@ -48,8 +47,8 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    open-AIMS/ssddata,
-    poissonconsulting/ssdtools
+    bcgov/ssdtools,
+    open-AIMS/ssddata
 Config/Needs/website: poissonconsulting/poissontemplate, rmarkdown
 Config/roxygen2/version: 8.0.0.9000
 Config/testthat/edition: 3

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
-[![R-CMD-check](https://github.com/poissonconsulting/ssdtests/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/poissonconsulting/ssdtests/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check](https://github.com/bcgov/ssdtests/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/bcgov/ssdtests/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
 The goal of ssdtests is to hold the slow and unstable tests for the

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
-[![R-CMD-check](https://github.com/poissonconsulting/ssdtests/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/poissonconsulting/ssdtests/actions/workflows/R-CMD-check.yaml)
+[![R-CMD-check](https://github.com/bcgov/ssdtests/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/bcgov/ssdtests/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
 The goal of ssdtests is to hold the slow and unstable tests for the

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,3 @@
-url: https://poissonconsulting.github.io/ssdtests/
+url: https://bcgov.github.io/ssdtests/
 template:
   package: poissontemplate

--- a/man/ssdtests-package.Rd
+++ b/man/ssdtests-package.Rd
@@ -11,9 +11,9 @@ Slow and unstable tests for ssdtools package.
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/poissonconsulting/ssdtests}
-  \item \url{https://poissonconsulting.github.io/ssdtests/}
-  \item Report bugs at \url{https://github.com/poissonconsulting/ssdtests/issues}
+  \item \url{https://github.com/bcgov/ssdtests}
+  \item \url{https://bcgov.github.io/ssdtests/}
+  \item Report bugs at \url{https://github.com/bcgov/ssdtests/issues}
 }
 
 }

--- a/scripts/ssdtools-coverage.R
+++ b/scripts/ssdtools-coverage.R
@@ -3,8 +3,8 @@
 # The ssdtools source is matched to the current ssdtests repo and branch: the
 # org is the owner of the `origin` remote and the branch is the same-named
 # branch on {org}/ssdtools (falling back to that repo's default branch). So
-# poissonconsulting/ssdtests@dev is measured against poissonconsulting/ssdtools@dev,
-# bcgov/ssdtests@main against bcgov/ssdtools@main, and so on.
+# bcgov/ssdtests@main is measured against bcgov/ssdtools@main,
+# poissonconsulting/ssdtests@dev against poissonconsulting/ssdtools@dev, and so on.
 #
 # Usage:
 #   Rscript scripts/ssdtools-coverage.R [--ref <branch>] [--filter <regex>] [--all]


### PR DESCRIPTION
The canonical `ssdtests` repository has moved to `bcgov/ssdtests`, with `poissonconsulting/ssdtests` now a development fork. This updates documentation, URLs, and badges accordingly.

## Changes
- `DESCRIPTION` — `URL`, `BugReports`, and the `ssdtools` `Remotes` entry now point to `bcgov` (also ran `use_tidy_description()`).
- `_pkgdown.yml` — site `url` set to `https://bcgov.github.io/ssdtests/`.
- `README.Rmd` / `README.md` — R-CMD-check badge points to `bcgov/ssdtests` (README rebuilt).
- `man/ssdtests-package.Rd` — regenerated from DESCRIPTION.
- `CONTRIBUTING.md` and `scripts/ssdtools-coverage.R` — coverage docs lead with `bcgov/ssdtests@main` vs `bcgov/ssdtools@main`, retaining the fork's `poissonconsulting@dev` mechanism.

## Not changed (intentional)
- CI workflows still use `poissonconsulting/.github` reusable workflows and `poisslack`, since active development stays on the fork.
- `_pkgdown.yml` still uses the `poissontemplate` pkgdown template.
- The released `0.2.0` NEWS entry is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)